### PR TITLE
Add production deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,69 @@
+name: Deploy to Production
+
+on:
+  # Run after the Docker image has been built and pushed to DockerHub.
+  workflow_run:
+    workflows: ["Docker CI"]
+    types:
+      - completed
+    branches:
+      - main
+  # Allow manual deploys from the Actions tab.
+  workflow_dispatch:
+
+# Only one deploy at a time; don't cancel an in-progress deploy.
+concurrency:
+  group: production-deploy
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    # For workflow_run triggers, only deploy when the build succeeded.
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+
+    env:
+      DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+      DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+      DEPLOY_COMPOSE_PATH: ${{ secrets.DEPLOY_COMPOSE_PATH }}
+      FIREWALL_ID: ${{ secrets.DO_FIREWALL_ID }}
+
+    steps:
+      - name: Install doctl
+        uses: digitalocean/action-doctl@v2
+        with:
+          token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
+
+      - name: Determine runner public IP
+        id: ip
+        run: echo "ip=$(curl -fsSL https://api.ipify.org)" >> "$GITHUB_OUTPUT"
+
+      - name: Open firewall for runner
+        env:
+          RUNNER_IP: ${{ steps.ip.outputs.ip }}
+        run: |
+          doctl compute firewall add-rules "$FIREWALL_ID" \
+            --inbound-rules "protocol:tcp,ports:22,address:${RUNNER_IP}/32"
+
+      - name: Configure SSH
+        run: |
+          mkdir -p ~/.ssh
+          chmod 700 ~/.ssh
+          echo "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: Deploy
+        run: |
+          ssh -i ~/.ssh/deploy_key "${DEPLOY_USER}@${DEPLOY_HOST}" \
+            "cd ${DEPLOY_COMPOSE_PATH} && docker compose pull web && docker compose up web -d && docker compose exec web python manage.py migrate --settings cattrack.settings_prod && docker image prune -f"
+
+      - name: Close firewall for runner
+        if: always()
+        env:
+          RUNNER_IP: ${{ steps.ip.outputs.ip }}
+        run: |
+          if [ -n "${RUNNER_IP}" ]; then
+            doctl compute firewall remove-rules "$FIREWALL_ID" \
+              --inbound-rules "protocol:tcp,ports:22,address:${RUNNER_IP}/32"
+          fi

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,8 +55,14 @@ jobs:
 
       - name: Deploy
         run: |
-          ssh -i ~/.ssh/deploy_key "${DEPLOY_USER}@${DEPLOY_HOST}" \
-            "cd ${DEPLOY_COMPOSE_PATH} && docker compose pull web && docker compose up web -d && docker compose exec web python manage.py migrate --settings cattrack.settings_prod && docker image prune -f"
+          ssh -i ~/.ssh/deploy_key "${DEPLOY_USER}@${DEPLOY_HOST}" "DEPLOY_COMPOSE_PATH='${DEPLOY_COMPOSE_PATH}' bash -s" <<'EOF'
+          set -e
+          cd "${DEPLOY_COMPOSE_PATH}"
+          docker compose pull web
+          docker compose up web -d
+          docker compose exec web python manage.py migrate --settings cattrack.settings_prod
+          docker image prune -f
+          EOF
 
       - name: Close firewall for runner
         if: always()


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/deploy.yml` to deploy to the production DigitalOcean droplet over SSH.
- Triggers automatically after the **Docker CI** workflow succeeds on `main` (so `dmkent/cattrack:latest` is already pushed), plus a manual `workflow_dispatch` button.
- Uses `doctl` to temporarily open the DO firewall (tcp/22) for the runner's public IP, runs the compose `pull`/`up`/`migrate`/`image prune` command, then **always** removes the firewall rule — even on failure.

## Why
We deploy via docker compose on a DO droplet behind a DO firewall. The action runner's IP changes each run, so the firewall must be opened dynamically for the SSH step and closed again afterward.

## Required GitHub secrets
| Secret | Purpose |
|---|---|
| `DIGITALOCEAN_ACCESS_TOKEN` | DO API token with firewall read/write |
| `DO_FIREWALL_ID` | ID of the firewall protecting the droplet (`doctl compute firewall list`) |
| `DEPLOY_SSH_KEY` | Private key for the dedicated deploy user |
| `DEPLOY_USER` | SSH user |
| `DEPLOY_HOST` | Droplet IP / hostname |
| `DEPLOY_COMPOSE_PATH` | Directory containing the compose file on the droplet |

## Reviewer notes
- `concurrency` prevents overlapping deploys from racing on the firewall rule, without cancelling an in-progress one.
- Firewall cleanup uses `if: always()` guarded on a non-empty IP, so a transient failure won't leave SSH permanently open.
- `workflow_run` only fires once this workflow exists on the default branch — until merged, test via the manual **Run workflow** button.
- Host key handling uses `ssh-keyscan` (TOFU). Can be swapped for a pinned known-host secret if stricter verification is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)