### PR TITLE
Potential fix for code scanning alert no. 4: Information exposure through an exception

### DIFF
--- a/ctrack/api/categorisor.py
+++ b/ctrack/api/categorisor.py
@@ -277,9 +277,10 @@ class CategorisorViewSet(viewsets.ModelViewSet):
         categorisor.set_training_metadata(**self._build_exclusion_summary(prepared))
         try:
             categorisor.fit_queryset(prepared['queryset'])
-        except ValueError as exc:
+        except ValueError:
+            logger.exception("Recalibration failed due to invalid training data configuration.")
             return response.Response(
-                {'error': str(exc) or 'Unable to recalibrate with the selected training data.'},
+                {'error': 'Unable to recalibrate with the selected training data.'},
                 status=status.HTTP_400_BAD_REQUEST,
             )
         bin_data = categorisor.to_bytes()

--- a/ctrack/api/transactions.py
+++ b/ctrack/api/transactions.py
@@ -85,8 +85,9 @@ class TransactionViewSet(viewsets.ModelViewSet):
                 return HttpResponseBadRequest("Invalid arguments.")
         try:
             transaction.split(args)
-        except Exception as thrown:
-            return response.Response("Unable to set categories: {}".format(thrown),
+        except Exception:
+            logger.exception("Unable to set categories for transaction split.")
+            return response.Response("Unable to set categories.",
                                      status=status.HTTP_400_BAD_REQUEST)
         return response.Response({"message": "Success"})
 


### PR DESCRIPTION
Potential fix for [https://github.com/dmkent/cattrack/security/code-scanning/4](https://github.com/dmkent/cattrack/security/code-scanning/4)

Use a generic client-facing error message and log the exception details on the server.

Best fix (without changing functionality): in `ctrack/api/categorisor.py`, within `recalibrate`, replace the response payload in the `except ValueError as exc:` block so it no longer includes `str(exc)`. Add a `logger.exception(...)` call in that block to preserve debugging information in server logs. Keep status code (`400`) and control flow unchanged.

No new imports are needed because `logger` is already defined.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
