### PR TITLE
Phase 3: serializer consolidation

### DIFF
--- a/ctrack/api/accounts.py
+++ b/ctrack/api/accounts.py
@@ -2,22 +2,13 @@
 """
 import logging
 from django.db.models import Max
-from rest_framework import (decorators, response,
-                            serializers, status, viewsets)
-from ctrack.api.data_serializer import LoadDataSerializer
-from ctrack.api.series_serializer import SeriesSerializer
+from rest_framework import (decorators, response, status, viewsets)
+from ctrack.api.serializers.common import LoadDataSerializer, SeriesSerializer
+from ctrack.api.serializers.accounts import AccountSerializer
 from ctrack.models import (Account, Category)
 
 
 logger = logging.getLogger(__name__)
-
-
-# Serializers define the API representation.
-class AccountSerializer(serializers.HyperlinkedModelSerializer):
-    last_transaction = serializers.DateTimeField(read_only=True)
-    class Meta:
-        model = Account
-        fields = ('url', 'id', 'name', 'balance', 'last_transaction')
 
 
 # ViewSets define the view behavior.

--- a/ctrack/api/budget_entry.py
+++ b/ctrack/api/budget_entry.py
@@ -2,16 +2,12 @@
 """
 import logging
 
-from rest_framework import serializers, viewsets
+from rest_framework import viewsets
+from ctrack.api.serializers.budget_entry import BudgetEntrySerializer
 from ctrack.models import BudgetEntry
 
 
 logger = logging.getLogger(__name__)
-
-class BudgetEntrySerializer(serializers.HyperlinkedModelSerializer):
-    class Meta:
-        model = BudgetEntry
-        fields = ('url', 'id', 'pretty_name', 'amount', 'valid_from', 'valid_to', 'categories')
 
 class BudgetEntryViewSet(viewsets.ModelViewSet):
     queryset = BudgetEntry.objects.all()

--- a/ctrack/api/categories.py
+++ b/ctrack/api/categories.py
@@ -7,32 +7,15 @@ from dateutil.parser import parse as parse_date
 from django.db.models import Sum
 from django.db.models.functions import TruncMonth
 from django.http import Http404
-from rest_framework import (decorators, generics, response,
-                            serializers, viewsets)
-from ctrack.api.series_serializer import SeriesSerializer
+from rest_framework import (decorators, generics, response, viewsets)
+from ctrack.api.serializers.common import SeriesSerializer
+from ctrack.api.serializers.categories import (
+    CategorySerializer, CategorySummarySerializer, ScoredCategorySerializer,
+)
 from ctrack.models import (Category, Transaction, BudgetEntry)
 
 
 logger = logging.getLogger(__name__)
-
-
-class CategorySerializer(serializers.HyperlinkedModelSerializer):
-    class Meta:
-        model = Category
-        fields = ('url', 'id', 'name')
-
-
-class ScoredCategorySerializer(serializers.Serializer):
-    id = serializers.IntegerField()
-    name = serializers.CharField(max_length=50)
-    score = serializers.IntegerField()
-
-
-class CategorySummarySerializer(serializers.Serializer):
-    id = serializers.IntegerField()
-    name = serializers.CharField(max_length=50)
-    value = serializers.FloatField()
-    budget = serializers.FloatField()
 
 
 class CategoryViewSet(viewsets.ModelViewSet):

--- a/ctrack/api/category_groups.py
+++ b/ctrack/api/category_groups.py
@@ -2,18 +2,12 @@
 
 from django.db.models import Q
 from django.utils.dateparse import parse_date
-from rest_framework import decorators, response, serializers, viewsets
+from rest_framework import decorators, response, viewsets
 import pandas as pd
 
 from ctrack.models import CategoryGroup, Transaction
-from ctrack.api.series_serializer import SeriesSerializer
-
-
-class CategoryGroupSerializer(serializers.HyperlinkedModelSerializer):
-    class Meta:
-        model = CategoryGroup
-        fields = ("url", "id", "name", "categories")
-        extra_kwargs = {"categories": {"required": False}}
+from ctrack.api.serializers.common import SeriesSerializer
+from ctrack.api.serializers.category_groups import CategoryGroupSerializer
 
 
 class CategoryGroupViewSet(viewsets.ModelViewSet):

--- a/ctrack/api/data_serializer.py
+++ b/ctrack/api/data_serializer.py
@@ -1,8 +1,0 @@
-"""ctrack REST API
-"""
-from rest_framework import serializers
-
-class LoadDataSerializer(serializers.Serializer):
-    data_file = serializers.FileField()
-    from_date = serializers.DateField(required=False, help_text="Start date for the data load")
-    to_date = serializers.DateField(required=False, help_text="End date for the data load")

--- a/ctrack/api/period_definition.py
+++ b/ctrack/api/period_definition.py
@@ -2,20 +2,12 @@
 
 import logging
 
-from rest_framework import response, serializers, views
+from rest_framework import response, views
+from ctrack.api.serializers.period_definition import PeriodDefinitionSerializer
 from ctrack.models import PeriodDefinition
 
 
 logger = logging.getLogger(__name__)
-
-
-class PeriodDefinitionSerializer(serializers.Serializer):
-    label = serializers.CharField(max_length=40)
-    from_date = serializers.DateField()
-    to_date = serializers.DateField()
-
-    id = serializers.IntegerField()
-    offset = serializers.IntegerField()
 
 
 class PeriodDefinitionView(views.APIView):

--- a/ctrack/api/progress.py
+++ b/ctrack/api/progress.py
@@ -8,8 +8,9 @@ from decimal import Decimal
 from dateutil.relativedelta import relativedelta
 from django.db.models import Sum
 from django.utils.dateparse import parse_date
-from rest_framework import response, serializers, views
+from rest_framework import response, views
 
+from ctrack.api.serializers.progress import ProgressResponseSerializer
 from ctrack.models import (
     BudgetEntry,
     Category,
@@ -20,43 +21,6 @@ from ctrack.models import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-# ---------------------------------------------------------------------------
-# Serializers
-# ---------------------------------------------------------------------------
-
-class ProgressPeriodSerializer(serializers.Serializer):
-    from_date = serializers.DateField()
-    to_date = serializers.DateField()
-    label = serializers.CharField()
-
-
-class UpcomingBillSerializer(serializers.Serializer):
-    name = serializers.CharField()
-    expected_date = serializers.DateField()
-    expected_amount = serializers.DecimalField(max_digits=8, decimal_places=2)
-
-
-class ProgressRowSerializer(serializers.Serializer):
-    id = serializers.IntegerField()
-    name = serializers.CharField()
-    actual_spend = serializers.DecimalField(max_digits=20, decimal_places=2)
-    expected_remaining = serializers.DecimalField(max_digits=20, decimal_places=2)
-    budget = serializers.DecimalField(max_digits=20, decimal_places=2, allow_null=True)
-    upcoming_bills = UpcomingBillSerializer(many=True)
-
-
-class ProgressTotalsSerializer(serializers.Serializer):
-    actual_spend = serializers.DecimalField(max_digits=20, decimal_places=2)
-    expected_remaining = serializers.DecimalField(max_digits=20, decimal_places=2)
-    budget = serializers.DecimalField(max_digits=20, decimal_places=2, allow_null=True)
-
-
-class ProgressResponseSerializer(serializers.Serializer):
-    period = ProgressPeriodSerializer()
-    rows = ProgressRowSerializer(many=True)
-    totals = ProgressTotalsSerializer()
 
 
 # ---------------------------------------------------------------------------

--- a/ctrack/api/recurring_payment.py
+++ b/ctrack/api/recurring_payment.py
@@ -2,7 +2,10 @@
 """
 import logging
 
-from ctrack.api.data_serializer import LoadDataSerializer
+from ctrack.api.serializers.common import LoadDataSerializer
+from ctrack.api.serializers.recurring_payment import (
+    BillSerializer, RecurringPaymentSerializer,
+)
 from ctrack.api.serializers.recurring_detection import (
     CreateFromDetectionSerializer,
     DetectRecurringRequestSerializer,
@@ -12,27 +15,9 @@ from django.db import transaction as db_transaction
 from ctrack.models import (Bill, RecurringPayment, Transaction)
 from ctrack.recurring_detection import RecurringTransactionDetector
 from django_filters import rest_framework as filters
-from rest_framework import (decorators, response,
-                            serializers, status, viewsets)
+from rest_framework import (decorators, response, status, viewsets)
 
 logger = logging.getLogger(__name__)
-
-
-class BillSerializer(serializers.ModelSerializer):
-    is_paid = serializers.ReadOnlyField()
-
-    class Meta:
-        model = Bill
-        fields = ('url', 'id', 'description', 'due_date', 'due_amount', 'fixed_amount', 'var_amount',
-                  'document', 'series', 'paying_transactions', 'is_paid')
-
-
-class RecurringPaymentSerializer(serializers.ModelSerializer):
-    bills = BillSerializer(many=True, read_only=True)
-
-    class Meta:
-        model = RecurringPayment
-        fields = ('url', 'id', 'name', 'is_income', 'bills', 'next_due_date', 'category')
 
 
 class RecurringPaymentViewSet(viewsets.ModelViewSet):

--- a/ctrack/api/serializers/accounts.py
+++ b/ctrack/api/serializers/accounts.py
@@ -1,0 +1,12 @@
+"""Serializers for the accounts API."""
+from rest_framework import serializers
+
+from ctrack.models import Account
+
+
+class AccountSerializer(serializers.HyperlinkedModelSerializer):
+    last_transaction = serializers.DateTimeField(read_only=True)
+
+    class Meta:
+        model = Account
+        fields = ('url', 'id', 'name', 'balance', 'last_transaction')

--- a/ctrack/api/serializers/budget_entry.py
+++ b/ctrack/api/serializers/budget_entry.py
@@ -1,0 +1,10 @@
+"""Serializers for the budget-entry API."""
+from rest_framework import serializers
+
+from ctrack.models import BudgetEntry
+
+
+class BudgetEntrySerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = BudgetEntry
+        fields = ('url', 'id', 'pretty_name', 'amount', 'valid_from', 'valid_to', 'categories')

--- a/ctrack/api/serializers/categories.py
+++ b/ctrack/api/serializers/categories.py
@@ -1,0 +1,23 @@
+"""Serializers for the categories API."""
+from rest_framework import serializers
+
+from ctrack.models import Category
+
+
+class CategorySerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = Category
+        fields = ('url', 'id', 'name')
+
+
+class ScoredCategorySerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    name = serializers.CharField(max_length=50)
+    score = serializers.IntegerField()
+
+
+class CategorySummarySerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    name = serializers.CharField(max_length=50)
+    value = serializers.FloatField()
+    budget = serializers.FloatField()

--- a/ctrack/api/serializers/category_groups.py
+++ b/ctrack/api/serializers/category_groups.py
@@ -1,0 +1,11 @@
+"""Serializers for the category-groups API."""
+from rest_framework import serializers
+
+from ctrack.models import CategoryGroup
+
+
+class CategoryGroupSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = CategoryGroup
+        fields = ("url", "id", "name", "categories")
+        extra_kwargs = {"categories": {"required": False}}

--- a/ctrack/api/serializers/common.py
+++ b/ctrack/api/serializers/common.py
@@ -1,0 +1,36 @@
+"""Shared serializers used across multiple API modules."""
+import os
+
+from rest_framework import serializers
+
+
+class SeriesSerializer(serializers.Serializer):
+    """A single (label, value) point in a time series."""
+    label = serializers.DateTimeField(source='dtime')
+    value = serializers.DecimalField(max_digits=20, decimal_places=2)
+
+
+class LoadDataSerializer(serializers.Serializer):
+    """Upload payload for importing transactions / bills from a file."""
+
+    # 25 MB ceiling — generous for statement exports, guards against abuse.
+    MAX_UPLOAD_SIZE = 25 * 1024 * 1024
+    ALLOWED_EXTENSIONS = ('.ofx', '.qfx', '.qif', '.pdf')
+
+    data_file = serializers.FileField()
+    from_date = serializers.DateField(required=False, help_text="Start date for the data load")
+    to_date = serializers.DateField(required=False, help_text="End date for the data load")
+
+    def validate_data_file(self, value):
+        if value.size > self.MAX_UPLOAD_SIZE:
+            max_mb = self.MAX_UPLOAD_SIZE // (1024 * 1024)
+            raise serializers.ValidationError(
+                f"File too large (max {max_mb} MB)."
+            )
+        ext = os.path.splitext(value.name)[1].lower()
+        if ext not in self.ALLOWED_EXTENSIONS:
+            allowed = ", ".join(self.ALLOWED_EXTENSIONS)
+            raise serializers.ValidationError(
+                f"Unsupported file type '{ext or value.name}'. Allowed: {allowed}."
+            )
+        return value

--- a/ctrack/api/serializers/period_definition.py
+++ b/ctrack/api/serializers/period_definition.py
@@ -1,0 +1,11 @@
+"""Serializers for the period-definition API."""
+from rest_framework import serializers
+
+
+class PeriodDefinitionSerializer(serializers.Serializer):
+    label = serializers.CharField(max_length=40)
+    from_date = serializers.DateField()
+    to_date = serializers.DateField()
+
+    id = serializers.IntegerField()
+    offset = serializers.IntegerField()

--- a/ctrack/api/serializers/progress.py
+++ b/ctrack/api/serializers/progress.py
@@ -1,0 +1,35 @@
+"""Serializers for the progress-tracking API."""
+from rest_framework import serializers
+
+
+class ProgressPeriodSerializer(serializers.Serializer):
+    from_date = serializers.DateField()
+    to_date = serializers.DateField()
+    label = serializers.CharField()
+
+
+class UpcomingBillSerializer(serializers.Serializer):
+    name = serializers.CharField()
+    expected_date = serializers.DateField()
+    expected_amount = serializers.DecimalField(max_digits=8, decimal_places=2)
+
+
+class ProgressRowSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    name = serializers.CharField()
+    actual_spend = serializers.DecimalField(max_digits=20, decimal_places=2)
+    expected_remaining = serializers.DecimalField(max_digits=20, decimal_places=2)
+    budget = serializers.DecimalField(max_digits=20, decimal_places=2, allow_null=True)
+    upcoming_bills = UpcomingBillSerializer(many=True)
+
+
+class ProgressTotalsSerializer(serializers.Serializer):
+    actual_spend = serializers.DecimalField(max_digits=20, decimal_places=2)
+    expected_remaining = serializers.DecimalField(max_digits=20, decimal_places=2)
+    budget = serializers.DecimalField(max_digits=20, decimal_places=2, allow_null=True)
+
+
+class ProgressResponseSerializer(serializers.Serializer):
+    period = ProgressPeriodSerializer()
+    rows = ProgressRowSerializer(many=True)
+    totals = ProgressTotalsSerializer()

--- a/ctrack/api/serializers/recurring_payment.py
+++ b/ctrack/api/serializers/recurring_payment.py
@@ -1,0 +1,21 @@
+"""Serializers for the recurring-payment / bills API."""
+from rest_framework import serializers
+
+from ctrack.models import Bill, RecurringPayment
+
+
+class BillSerializer(serializers.ModelSerializer):
+    is_paid = serializers.ReadOnlyField()
+
+    class Meta:
+        model = Bill
+        fields = ('url', 'id', 'description', 'due_date', 'due_amount', 'fixed_amount', 'var_amount',
+                  'document', 'series', 'paying_transactions', 'is_paid')
+
+
+class RecurringPaymentSerializer(serializers.ModelSerializer):
+    bills = BillSerializer(many=True, read_only=True)
+
+    class Meta:
+        model = RecurringPayment
+        fields = ('url', 'id', 'name', 'is_income', 'bills', 'next_due_date', 'category')

--- a/ctrack/api/serializers/transactions.py
+++ b/ctrack/api/serializers/transactions.py
@@ -1,0 +1,35 @@
+"""Serializers for the transactions API."""
+from rest_framework import serializers
+
+from ctrack.models import Category, Transaction
+
+
+class TransactionSerializer(serializers.ModelSerializer):
+    category_name = serializers.ReadOnlyField(source='category.name')
+
+    class Meta:
+        model = Transaction
+        fields = ('url', 'id', 'when', 'amount', 'description', 'category', 'category_name', 'account')
+
+
+class SplitTransSerializer(serializers.Serializer):
+    category = serializers.PrimaryKeyRelatedField(queryset=Category.objects.all())
+    amount = serializers.DecimalField(max_digits=10, decimal_places=2)
+
+
+class SummarySerializer(serializers.Serializer):
+    category = serializers.IntegerField(allow_null=True)
+    category_name = serializers.CharField(max_length=100, source='category__name', allow_null=True)
+    subcategory = serializers.SerializerMethodField()
+    total = serializers.DecimalField(max_digits=20, decimal_places=2)
+
+    def get_subcategory(self, obj):
+        return Category.subcategory_prefix_from_name(obj.get('category__name'))
+
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+        if data.get('category_name') is None:
+            data['category_name'] = "None"
+        if data.get('subcategory') is None:
+            data['subcategory'] = "None"
+        return data

--- a/ctrack/api/series_serializer.py
+++ b/ctrack/api/series_serializer.py
@@ -1,7 +1,0 @@
-"""ctrack REST API
-"""
-from rest_framework import (serializers)
-
-class SeriesSerializer(serializers.Serializer):
-    label = serializers.DateTimeField(source='dtime')
-    value = serializers.DecimalField(max_digits=20, decimal_places=2)

--- a/ctrack/api/transactions.py
+++ b/ctrack/api/transactions.py
@@ -5,50 +5,22 @@ import logging
 from django.db.models import Sum
 from django.http import HttpResponseBadRequest
 from rest_framework import (decorators, pagination, response,
-                            serializers, status, viewsets)
+                            status, viewsets)
 from django_filters import rest_framework as filters
 import django_filters
-from ctrack.models import (Category, Transaction)
+from ctrack.models import Transaction
+from ctrack.api.serializers.transactions import (
+    SplitTransSerializer, SummarySerializer, TransactionSerializer,
+)
 
 
 logger = logging.getLogger(__name__)
-
-
-class TransactionSerializer(serializers.ModelSerializer):
-    category_name = serializers.ReadOnlyField(source='category.name')
-
-    class Meta:
-        model = Transaction
-        fields = ('url', 'id', 'when', 'amount', 'description', 'category', 'category_name', 'account')
-
-
-class SplitTransSerializer(serializers.Serializer):
-    category = serializers.PrimaryKeyRelatedField(queryset=Category.objects.all())
-    amount = serializers.DecimalField(max_digits=10, decimal_places=2)
 
 
 # ViewSets define the view behavior.
 class PageNumberSettablePagination(pagination.PageNumberPagination):
     page_size_query_param = 'page_size'
     page_size = 100
-
-
-class SummarySerializer(serializers.Serializer):
-    category = serializers.IntegerField(allow_null=True)
-    category_name = serializers.CharField(max_length=100, source='category__name', allow_null=True)
-    subcategory = serializers.SerializerMethodField()
-    total = serializers.DecimalField(max_digits=20, decimal_places=2)
-
-    def get_subcategory(self, obj):
-        return Category.subcategory_prefix_from_name(obj.get('category__name'))
-
-    def to_representation(self, instance):
-        data = super().to_representation(instance)
-        if data.get('category_name') is None:
-            data['category_name'] = "None"
-        if data.get('subcategory') is None:
-            data['subcategory'] = "None"
-        return data
 
 
 class DateRangeTransactionFilter(filters.FilterSet):

--- a/ctrack/test_upload_serializer.py
+++ b/ctrack/test_upload_serializer.py
@@ -1,0 +1,29 @@
+"""Tests for file-upload validation on LoadDataSerializer."""
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase
+
+from ctrack.api.serializers.common import LoadDataSerializer
+
+
+class LoadDataSerializerTests(TestCase):
+    def _upload(self, name, content=b"data"):
+        return SimpleUploadedFile(name, content)
+
+    def test_accepts_allowed_extension(self):
+        serializer = LoadDataSerializer(data={"data_file": self._upload("statement.ofx")})
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+    def test_accepts_pdf(self):
+        serializer = LoadDataSerializer(data={"data_file": self._upload("bill.PDF")})
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+
+    def test_rejects_unknown_extension(self):
+        serializer = LoadDataSerializer(data={"data_file": self._upload("notes.txt")})
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("data_file", serializer.errors)
+
+    def test_rejects_oversized_file(self):
+        big = b"x" * (LoadDataSerializer.MAX_UPLOAD_SIZE + 1)
+        serializer = LoadDataSerializer(data={"data_file": self._upload("statement.ofx", big)})
+        self.assertFalse(serializer.is_valid())
+        self.assertIn("data_file", serializer.errors)


### PR DESCRIPTION
## Phase 3 — Serializer consolidation

Establishes one rule: **all serializers live under `ctrack/api/serializers/`**, one module per domain. Part of the phased CatTrack structural cleanup.

### Changes
- Moved every inline serializer out of the API view modules into matching `serializers/<domain>.py` modules: `transactions`, `categories`, `accounts`, `recurring_payment`, `progress`, `budget_entry`, `category_groups`, `period_definition`.
- Folded the stray top-level `ctrack/api/data_serializer.py` and `ctrack/api/series_serializer.py` into a new `serializers/common.py` (`SeriesSerializer`, `LoadDataSerializer`); deleted the old files.
- Added file-upload validation (25 MB size ceiling + extension allow-list) to `LoadDataSerializer`, which backs `AccountViewSet.load` and `RecurringPaymentViewSet.loadpdf`, with tests.

### Notes
- The `SummarySerializer.subcategory` field is kept as a `SerializerMethodField`: its queryset yields `.values()` dicts (not model instances), so `source=` to a model property is not applicable. It already delegates to the reusable `Category.subcategory_prefix_from_name` static method.
- No `fields = '__all__'` usages were found.

### Validation
- `manage.py test`: **123 passed** (119 prior + 4 new upload-validation tests).
- `makemigrations --check --dry-run`: no changes (no model edits).
- OpenAPI schema diff vs baseline: **empty** (no field renames; upload validation is request-side and not surfaced by spectacular).

🤖 Generated with [Claude Code](https://claude.com/claude-code)