### PR TITLE
Add Dependabot with 7-day cooldown for pip dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` to enable Dependabot for pip dependencies
- Configured with a 7-day cooldown so PRs are only opened for package versions that have been available for at least a week, reducing churn from rapid follow-up releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)